### PR TITLE
Support current gomemcache interface

### DIFF
--- a/ketama/ketama.go
+++ b/ketama/ketama.go
@@ -181,3 +181,18 @@ func (cont *Continuum) PickServer(key string) (net.Addr, error) {
 	}
 	return cont.array[i].addr, nil
 }
+
+// Each iterates over each server calling the given function
+func (cont *Continuum) Each(f func(net.Addr) error) error {
+	seen := make(map[net.Addr]bool)
+	for _, a := range cont.array {
+		if seen[a.addr] {
+			continue
+		}
+		seen[a.addr] = true
+		if err := f(a.addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/ketama/ketama.go
+++ b/ketama/ketama.go
@@ -148,7 +148,7 @@ func New(serverList []ServerInfo) *Continuum {
 		ks := int(math.Floor(pct * 40.0 * float64(numServers)))
 
 		for k := 0; k < ks; k++ {
-			ss := fmt.Sprintf("%s-%v", server.Addr, k)
+			ss := fmt.Sprintf("%s-%d", server.Addr, k)
 			digest := md5Digest([]byte(ss))
 
 			for h := 0; h < 4; h++ {

--- a/ketama/ketama.go
+++ b/ketama/ketama.go
@@ -1,41 +1,41 @@
 package ketama
 
 import (
-    "bufio"
-    "crypto/md5"
-    "errors"
-    "fmt"
-    "io"
-    "math"
-    "net"
-    "os"
-    "sort"
-    "strconv"
-    "strings"
-    "time"
+	"bufio"
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 )
 
 var (
-    ErrNoServers       = errors.New("No valid server definitions found")
-    ErrMalformedServer = errors.New("One of the servers is in an invalid format")
+	ErrNoServers       = errors.New("No valid server definitions found")
+	ErrMalformedServer = errors.New("One of the servers is in an invalid format")
 )
 
 type mcs struct {
-    point uint
-    addr  net.Addr
+	point uint
+	addr  net.Addr
 }
 
 type mcsArray []mcs
 
 type ServerInfo struct {
-    addr   net.Addr
-    memory uint64
+	addr   net.Addr
+	memory uint64
 }
 
 type Continuum struct {
-    numpoints int
-    modtime   time.Time
-    array     mcsArray
+	numpoints int
+	modtime   time.Time
+	array     mcsArray
 }
 
 func (s mcsArray) Less(i, j int) bool { return s[i].point < s[j].point }
@@ -45,127 +45,127 @@ func (s mcsArray) Sort()              { sort.Sort(s) }
 
 // Should be "servername:port\tmemory"
 func readServerDefinitions(filename string) (ss []ServerInfo, memory uint64, err error) {
-    file, err := os.Open(filename)
-    if err != nil {
-        return nil, 0, err
-    }
-    reader := bufio.NewReader(file)
-    ss = make([]ServerInfo, 0)
-    memory = uint64(0)
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, 0, err
+	}
+	reader := bufio.NewReader(file)
+	ss = make([]ServerInfo, 0)
+	memory = uint64(0)
 
-    for {
-        data, _, err := reader.ReadLine()
-        if err == io.EOF {
-            break
-        } else if err != nil {
-            return nil, 0, err
-        }
-        line := string(data)
-        if strings.HasPrefix(line, "#") {
-            continue
-        }
-        addr, mem, err := getServerAddr(line)
-        if err != nil {
-            return nil, 0, err
-        }
+	for {
+		data, _, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, 0, err
+		}
+		line := string(data)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		addr, mem, err := getServerAddr(line)
+		if err != nil {
+			return nil, 0, err
+		}
 
-        s := ServerInfo{
-            addr:   addr,
-            memory: mem,
-        }
-        ss = append(ss, s)
-        memory += mem
-    }
-    return ss, memory, nil
+		s := ServerInfo{
+			addr:   addr,
+			memory: mem,
+		}
+		ss = append(ss, s)
+		memory += mem
+	}
+	return ss, memory, nil
 }
 
 func md5Digest(in []byte) []byte {
-    h := md5.New()
-    h.Write(in)
-    return h.Sum(nil)
+	h := md5.New()
+	h.Write(in)
+	return h.Sum(nil)
 }
 
 func getServerAddr(line string) (addr net.Addr, mem uint64, err error) {
-    record := strings.Split(string(line), "\t")
-    if len(record) != 2 {
-        return nil, 0, ErrMalformedServer
-    }
-    mem, err = strconv.ParseUint(record[1], 10, 0)
-    if err != nil {
-        return nil, 0, ErrMalformedServer
-    }
-    if strings.Contains(record[0], "/") {
-        addr, err = net.ResolveUnixAddr("unix", record[0])
-    } else {
-        addr, err = net.ResolveTCPAddr("tcp", record[0])
-    }
-    return
+	record := strings.Split(string(line), "\t")
+	if len(record) != 2 {
+		return nil, 0, ErrMalformedServer
+	}
+	mem, err = strconv.ParseUint(record[1], 10, 0)
+	if err != nil {
+		return nil, 0, ErrMalformedServer
+	}
+	if strings.Contains(record[0], "/") {
+		addr, err = net.ResolveUnixAddr("unix", record[0])
+	} else {
+		addr, err = net.ResolveTCPAddr("tcp", record[0])
+	}
+	return
 }
 
 func GetHash(in string) uint {
-    digest := md5Digest([]byte(in))
-    return ((uint(digest[3]) << 24) |
-        (uint(digest[2]) << 16) |
-        (uint(digest[1]) << 8) |
-        uint(digest[0]))
+	digest := md5Digest([]byte(in))
+	return ((uint(digest[3]) << 24) |
+		(uint(digest[2]) << 16) |
+		(uint(digest[1]) << 8) |
+		uint(digest[0]))
 }
 
 func NewFromFile(filename string) (*Continuum, error) {
-    fileInfo, err := os.Stat(filename)
-    if err != nil {
-        return nil, err
-    }
-    serverList, memory, err := readServerDefinitions(filename)
-    if err != nil {
-        return nil, err
-    }
-    numServers := len(serverList)
-    if numServers < 1 {
-        return nil, ErrNoServers
-    }
+	fileInfo, err := os.Stat(filename)
+	if err != nil {
+		return nil, err
+	}
+	serverList, memory, err := readServerDefinitions(filename)
+	if err != nil {
+		return nil, err
+	}
+	numServers := len(serverList)
+	if numServers < 1 {
+		return nil, ErrNoServers
+	}
 
-    continuum := &Continuum{
-        array: make([]mcs, numServers*160),
-    }
+	continuum := &Continuum{
+		array: make([]mcs, numServers*160),
+	}
 
-    cont := 0
+	cont := 0
 
-    for _, server := range serverList {
-        pct := float64(server.memory) / float64(memory)
-        ks := int(math.Floor(pct * 40.0 * float64(numServers)))
+	for _, server := range serverList {
+		pct := float64(server.memory) / float64(memory)
+		ks := int(math.Floor(pct * 40.0 * float64(numServers)))
 
-        for k := 0; k < ks; k++ {
-            ss := fmt.Sprintf("%s-%v", server.addr.String(), k)
-            digest := md5Digest([]byte(ss))
+		for k := 0; k < ks; k++ {
+			ss := fmt.Sprintf("%s-%v", server.addr.String(), k)
+			digest := md5Digest([]byte(ss))
 
-            for h := 0; h < 4; h++ {
-                continuum.array[cont].point = ((uint(digest[3+h*4]) << 24) |
-                    (uint(digest[2+h*4]) << 16) |
-                    (uint(digest[1+h*4]) << 8) |
-                    uint(digest[h*4]))
-                continuum.array[cont].addr = server.addr
-                cont++
-            }
-        }
-    }
+			for h := 0; h < 4; h++ {
+				continuum.array[cont].point = ((uint(digest[3+h*4]) << 24) |
+					(uint(digest[2+h*4]) << 16) |
+					(uint(digest[1+h*4]) << 8) |
+					uint(digest[h*4]))
+				continuum.array[cont].addr = server.addr
+				cont++
+			}
+		}
+	}
 
-    continuum.array.Sort()
-    continuum.numpoints = cont
-    continuum.modtime = fileInfo.ModTime()
+	continuum.array.Sort()
+	continuum.numpoints = cont
+	continuum.modtime = fileInfo.ModTime()
 
-    return continuum, nil
+	return continuum, nil
 }
 
 func (cont *Continuum) PickServer(key string) (net.Addr, error) {
 
-    if len(cont.array) == 0 {
-        return nil, ErrNoServers
-    }
+	if len(cont.array) == 0 {
+		return nil, ErrNoServers
+	}
 
-    h := GetHash(key)
-    i := sort.Search(len(cont.array), func(i int) bool { return cont.array[i].point >= h })
-    if i >= len(cont.array) {
-        i = 0
-    }
-    return cont.array[i].addr, nil
+	h := GetHash(key)
+	i := sort.Search(len(cont.array), func(i int) bool { return cont.array[i].point >= h })
+	if i >= len(cont.array) {
+		i = 0
+	}
+	return cont.array[i].addr, nil
 }

--- a/ketama/ketama_test.go
+++ b/ketama/ketama_test.go
@@ -18,6 +18,7 @@ func TestContinuumDistribution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create continuum: %v", err)
 	}
+
 	serverMap := make(map[string]int)
 	for i := 0; i < 10000; i++ {
 		server, _ := cont.PickServer(strconv.Itoa(i))
@@ -30,11 +31,11 @@ func TestContinuumDistribution(t *testing.T) {
 
 	// Value should be roughly equal to 10000 / num_servers
 	target := float64(10000) / float64(len(serverMap))
-	error := float64(target * .15)
-	for _, v := range serverMap {
+	errorRange := float64(target * .18)
+	for k, v := range serverMap {
 		v := float64(v)
-		if v > target+error || v < target-error {
-			t.Errorf("Server had %v keys, should have %v (+- 15%%)", v, target)
+		if v > target+errorRange || v < target-errorRange {
+			t.Errorf("Server address %s had %v keys, should have %v (+/- 18%%)", k, v, target)
 		}
 	}
 }

--- a/ketama/ketama_test.go
+++ b/ketama/ketama_test.go
@@ -1,39 +1,39 @@
 package ketama
 
 import (
-    "strconv"
-    "testing"
+	"strconv"
+	"testing"
 )
 
 func BenchmarkDistribution(b *testing.B) {
-    cont, _ := NewFromFile("../testdata/servers.test")
-    for i := 0; i < b.N; i++ {
-        cont.PickServer(strconv.Itoa(i))
-    }
+	cont, _ := NewFromFile("../testdata/servers.test")
+	for i := 0; i < b.N; i++ {
+		cont.PickServer(strconv.Itoa(i))
+	}
 }
 
 func TestContinuumDistribution(t *testing.T) {
-    cont, err := NewFromFile("../testdata/servers.test")
-    if err != nil {
-        t.Fatalf("Failed to create continuum: %v", err)
-    }
-    serverMap := make(map[string]int)
-    for i := 0; i < 10000; i++ {
-        server, _ := cont.PickServer(strconv.Itoa(i))
-        serverMap[server.String()] += 1
-    }
+	cont, err := NewFromFile("../testdata/servers.test")
+	if err != nil {
+		t.Fatalf("Failed to create continuum: %v", err)
+	}
+	serverMap := make(map[string]int)
+	for i := 0; i < 10000; i++ {
+		server, _ := cont.PickServer(strconv.Itoa(i))
+		serverMap[server.String()] += 1
+	}
 
-    if len(serverMap) != 10 {
-        t.Fatalf("Did not pick 1 or more servers")
-    }
+	if len(serverMap) != 10 {
+		t.Fatalf("Did not pick 1 or more servers")
+	}
 
-    // Value should be roughly equal to 10000 / num_servers
-    target := float64(10000) / float64(len(serverMap))
-    error := float64(target * .15)
-    for _, v := range serverMap {
-        v := float64(v)
-        if v > target+error || v < target-error {
-            t.Errorf("Server had %v keys, should have %v (+- 15%%)", v, target)
-        }
-    }
+	// Value should be roughly equal to 10000 / num_servers
+	target := float64(10000) / float64(len(serverMap))
+	error := float64(target * .15)
+	for _, v := range serverMap {
+		v := float64(v)
+		if v > target+error || v < target-error {
+			t.Errorf("Server had %v keys, should have %v (+- 15%%)", v, target)
+		}
+	}
 }

--- a/ketama/ketama_test.go
+++ b/ketama/ketama_test.go
@@ -1,6 +1,7 @@
 package ketama
 
 import (
+	"net"
 	"strconv"
 	"testing"
 )
@@ -35,5 +36,20 @@ func TestContinuumDistribution(t *testing.T) {
 		if v > target+error || v < target-error {
 			t.Errorf("Server had %v keys, should have %v (+- 15%%)", v, target)
 		}
+	}
+}
+
+func TestContinuumEach(t *testing.T) {
+	cont, err := NewFromFile("../testdata/servers.test")
+	if err != nil {
+		t.Fatalf("Failed to create continuum: %v", err)
+	}
+	var count int
+	cont.Each(func(n net.Addr) error {
+		count += 1
+		return nil
+	})
+	if count != 10 {
+		t.Fatalf("did not Each() all servers")
 	}
 }


### PR DESCRIPTION
bradfitz/gomemcache#12 added the requirement to support `Each(func(net.Addr) error) error` and this does that.

(This also is rebased on a branch that add's `New()` support for constructing a server list without using a file.