### PR TITLE
Configurable hash

### DIFF
--- a/ketama/ketama_test.go
+++ b/ketama/ketama_test.go
@@ -1,6 +1,7 @@
 package ketama
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"testing"
@@ -36,6 +37,44 @@ func TestContinuumDistribution(t *testing.T) {
 		v := float64(v)
 		if v > target+errorRange || v < target-errorRange {
 			t.Errorf("Server address %s had %v keys, should have %v (+/- 18%%)", k, v, target)
+		}
+	}
+}
+
+func TestNonWeightedDistribution(t *testing.T) {
+	var servers []ServerInfo
+	for i := 1; i < 11; i++ {
+		ss := fmt.Sprintf("%d0.%d0.%d0.%d0:11211", i, i, i, i)
+		a, err := net.ResolveTCPAddr("tcp", ss)
+		if err != nil {
+			t.Fatalf("Failed resolving: %v", err)
+		}
+		servers = append(servers, ServerInfo{a, 0})
+	}
+
+	cont := New(servers, nil)
+
+	serverMap := make(map[string]int)
+	for i := 0; i < 10000; i++ {
+		server, err := cont.PickServer(strconv.Itoa(i))
+		if err != nil {
+			t.Fatalf("Failed picking: %v", err)
+		}
+		// log.Printf("picked %s %s", server, err)
+		serverMap[server.String()] += 1
+	}
+
+	if len(serverMap) != 10 {
+		t.Fatalf("Did not pick 1 or more servers")
+	}
+
+	// Value should be roughly equal to 10000 / num_servers
+	target := float64(10000) / float64(len(serverMap))
+	errorRange := float64(target * .25)
+	for k, v := range serverMap {
+		v := float64(v)
+		if v > target+errorRange || v < target-errorRange {
+			t.Errorf("Server address %s had %v keys, should have %v (+/- 25%%)", k, v, target)
 		}
 	}
 }


### PR DESCRIPTION
I've been steadily chasing compatibility here with existing code that uses libmemcached. I thought #3 would do the trick, but I've forgotten how hard it to follow along in a decent sized C code base :rotating_light:, and missed a few details which surfaced as i validated implementation :cry:.

sidenote: As is, i believe master is compatible with weighted ketama as implemented in libmemcached and current gomemcache, but i've not audited the two.

I found that there are actually some implications if you don't use a weighted ketama setup in libevent

1) there are 100 points per address not 160
3) There are not 4 points added per ring spot (just one)
3) a different hash function is chosen ([Jenkins one-at-a-time](http://en.wikipedia.org/wiki/Jenkins_hash_function)) instead of md5. The existing conversion from md5 digest to uint32 is also skipped.

I've made the code handle weighted configs better, and have audited this works for me (though i've not gotten this into production yet).

In pursuit of this I've made a few small API changes:

* `New()` (the function added in #3) takes a function which returns a hash algorithim (this allows me to plug  [NewJenkins32](http://godoc.org/github.com/dgryski/dgohash#NewJenkins32)
* `GetHash(key)` moved to `func (cont * Continuum) GetHash(key string, offset int)` to have access to the hash function algorithim.
* New logic is pivoted on all `Memory` (aka weights) being zero.

@rckclmbr If this diff sounds good, let me know and i'll update here once i'm comfortable with this changeset being reliable and sufficient for my needs :rocket: . If you have thoughts on a different approach than i've taken, i'm all :ear:'s